### PR TITLE
To fix the error "index out of range" when calling FP256BN.FromBytes(...)

### DIFF
--- a/amcl/FP256BN/BIG.go
+++ b/amcl/FP256BN/BIG.go
@@ -476,9 +476,14 @@ func (r *BIG) tobytearray(b []byte, n int) {
 /* convert from byte array to BIG */
 func frombytearray(b []byte, n int) *BIG {
 	m := NewBIG()
+	l := len(b)
 	for i := 0; i < int(MODBYTES); i++ {
 		m.fshl(8)
-		m.w[0] += Chunk(int(b[i+n] & 0xff))
+		if i < l {
+			m.w[0] += Chunk(int(b[i+n] & 0xff))
+		} else {
+			m.w[0] += Chunk(int(0 & 0xff))
+		}
 	}
 	return m
 }


### PR DESCRIPTION
**Purpose:**

To fix the error "index out of range" when calling _FP256BN.FromBytes([]byte("123"))_. This is needed to test idemix with custom attribute values such as "123", "bob" and so on.

The current implementation of "_frombytearray_" (which is called by "_FromBytes_") expects that the input byte array 'b' to be of specific length "int(MODBYTES)". However, this restricts the flexibility of using custom attribute values such as strings in testing idemix.

**Steps to reproduce:**

1.  `git clone https://github.com/hyperledger/fabric.git`
2.  `cd fabric/idemix`
3.  edit _idemix_test.go_ and add the following line to line number 40

    ` attrs[0] = FP256BN.FromBytes([]byte("Bob"))`

4.  `go test -v`

**Expected output:**

The tests should pass without any error.

**Actual output:**

```
=== RUN   TestIdemix
--- FAIL: TestIdemix (0.04s)
panic: runtime error: index out of range [3] with length 3 [recovered]
	panic: runtime error: index out of range [3] with length 3

goroutine 18 [running]:
testing.tRunner.func1.1(0x7fa6c0, 0xc00001a380)
	/usr/local/go/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc0001166c0)
	/usr/local/go/src/testing/testing.go:943 +0x3f9
panic(0x7fa6c0, 0xc00001a380)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/hyperledger/fabric-amcl/amcl/FP256BN.frombytearray(0xc000043dc7, 0x3, 0x3, 0x0, 0x0)
	/home/vignesh/go/src/github.com/hyperledger/fabric/vendor/github.com/hyperledger/fabric-amcl/amcl/FP256BN/BIG.go:481 +0x9d
github.com/hyperledger/fabric-amcl/amcl/FP256BN.FromBytes(...)
	/home/vignesh/go/src/github.com/hyperledger/fabric/vendor/github.com/hyperledger/fabric-amcl/amcl/FP256BN/BIG.go:491
github.com/hyperledger/fabric/idemix.TestIdemix(0xc0001166c0)
	/home/vignesh/go/src/github.com/hyperledger/fabric/idemix/idemix_test.go:40 +0x29e
testing.tRunner(0xc0001166c0, 0x83cba8)
	/usr/local/go/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1042 +0x357
exit status 2
FAIL	github.com/hyperledger/fabric/idemix	0.072s
```
