### PR TITLE
Correct build tags

### DIFF
--- a/amcl/FP256BN/ARCH.go
+++ b/amcl/FP256BN/ARCH.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/BIG.go
+++ b/amcl/FP256BN/BIG.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/BLS.go
+++ b/amcl/FP256BN/BLS.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/CONFIG_BIG.go
+++ b/amcl/FP256BN/CONFIG_BIG.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 package FP256BN
 

--- a/amcl/FP256BN/CONFIG_FIELD.go
+++ b/amcl/FP256BN/CONFIG_FIELD.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 package FP256BN
 

--- a/amcl/FP256BN/DBIG.go
+++ b/amcl/FP256BN/DBIG.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/ECDH.go
+++ b/amcl/FP256BN/ECDH.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/ECP.go
+++ b/amcl/FP256BN/ECP.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/ECP2.go
+++ b/amcl/FP256BN/ECP2.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/FP.go
+++ b/amcl/FP256BN/FP.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/FP12.go
+++ b/amcl/FP256BN/FP12.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/FP2.go
+++ b/amcl/FP256BN/FP2.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/FP4.go
+++ b/amcl/FP256BN/FP4.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/MPIN.go
+++ b/amcl/FP256BN/MPIN.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/PAIR.go
+++ b/amcl/FP256BN/PAIR.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/amcl/FP256BN/ROM.go
+++ b/amcl/FP256BN/ROM.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
 Licensed to the Apache Software Foundation (ASF) under one

--- a/core/FP256BN/ARCH.go
+++ b/core/FP256BN/ARCH.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/BIG.go
+++ b/core/FP256BN/BIG.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/BLS.go
+++ b/core/FP256BN/BLS.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/CONFIG_BIG.go
+++ b/core/FP256BN/CONFIG_BIG.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/CONFIG_FIELD.go
+++ b/core/FP256BN/CONFIG_FIELD.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/ECDH.go
+++ b/core/FP256BN/ECDH.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/EDDSA.go
+++ b/core/FP256BN/EDDSA.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/FP.go
+++ b/core/FP256BN/FP.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/FP2.go
+++ b/core/FP256BN/FP2.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/FP4.go
+++ b/core/FP256BN/FP4.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/HPKE.go
+++ b/core/FP256BN/HPKE.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/MPIN.go
+++ b/core/FP256BN/MPIN.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.

--- a/core/FP256BN/ROM.go
+++ b/core/FP256BN/ROM.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64
+//go:build !386 && !arm
 
 /*
  * Copyright (c) 2012-2020 MIRACL UK Ltd.


### PR DESCRIPTION
The previous patch used

```
//go:build amd64 || arm64
```

as build tag for 64-bit architectures. However this was unvoluntarily discarding other 64-bit platforms (such as `wasm`) that were previously supported. The issue has been fixed by replacing the tag with

```
//go:build !386 && !arm
```